### PR TITLE
Issue 3 user can save stock to watchlist

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -201,6 +201,14 @@ i.fa-pen {
   background-color: #b6ecb4;
 }
 
+.profit-text{
+  color: green;
+}
+
+.loss-text{
+  color: red;
+}
+
 @media only screen and (min-width: 768px) {
   .container {
     width: 760px;

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         </section>
       </div>
     </div>
-    <div class="stock-page container row " data-view="stockPage">
+    <div class="stock-page container row hidden" data-view="stockPage">
       <header class="overview-header search-bar column-full row">
         <h2 class="watchlist-text">Overview</h2>
         <i class="fas fa-plus"></i>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         </section>
       </div>
     </div>
-    <div class="stock-page container row hidden" data-view="stockPage">
+    <div class="stock-page container row " data-view="stockPage">
       <header class="overview-header search-bar column-full row">
         <h2 class="watchlist-text">Overview</h2>
         <i class="fas fa-plus"></i>

--- a/js/data.js
+++ b/js/data.js
@@ -2,5 +2,12 @@
 var data = {
   view: null,
   suggestionData: null,
-  currentStock: []
+  currentStock: [],
+  currentIssueId: null,
+  wachlist: [
+    {
+      ticker: 'APPL',
+      issueId: '36276'
+    }
+  ]
 }

--- a/js/data.js
+++ b/js/data.js
@@ -3,6 +3,18 @@ var data = {
   view: null,
   suggestionData: null,
   currentStock: [],
-  currentIssueId: null,
-  wachlist: [  ]
+  watchlist: []
 }
+var previousDataJSON = localStorage.getItem('watchlistData');
+
+if(previousDataJSON !== null){
+  data = JSON.parse(previousDataJSON);
+}else console.log('noDAta');
+
+window.addEventListener('beforeunload', function(){
+  data.view = null;
+  data.suggestionData = null;
+  data.currentStock = [];
+  var dataJSON = JSON.stringify(data);
+  localStorage.setItem('watchlistData', dataJSON);
+});

--- a/js/data.js
+++ b/js/data.js
@@ -4,10 +4,5 @@ var data = {
   suggestionData: null,
   currentStock: [],
   currentIssueId: null,
-  wachlist: [
-    {
-      ticker: 'APPL',
-      issueId: '36276'
-    }
-  ]
+  wachlist: [  ]
 }

--- a/js/main.js
+++ b/js/main.js
@@ -11,6 +11,7 @@ var overviewStatsRequest = 'OVERVIEW';
 var trendingStoriesRequest = 'TRENDING';
 var companyNewsRequest = 'SYMBOL_NEWS';
 var autoCompleteRequest = 'AUTO';
+var issueIdRequest = 'ISSUE_ID';
 
 // Functions
 function autoCompleteSuggest(event) {
@@ -39,7 +40,7 @@ function submitSearch(event) {
   clearRelatedNews();
   sendRequestAlphaVantage(overviewStatsRequest, $searchInput.value);
   sendRequestAlphaVantage(dailyStatsRequest, $searchInput.value);
-  sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
+  // sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
   $searchInput.value = '';
   removeSuggestionList();
   switchPage(event.target);
@@ -145,6 +146,14 @@ function clearRelatedNews() {
   }
 }
 
+function saveToWatchlist(symbol, id){
+  var watchlistObject = {}
+  watchlistObject.ticker = symbol;
+  watchlistObject.issueId = id;
+  data.wachlist.push(watchlistObject);
+  //create list item with current data, future log-on will create items from local storage
+}
+
 // Request Functions
 function sendRequestAlphaVantage(functionType, ticker) {
   var xhr = new XMLHttpRequest();
@@ -182,7 +191,14 @@ function sendRequestCNBC(requestType, ticker, input) {
       responseObject = JSON.parse(xhr.response);
       responseObject = responseObject.rss.channel.item;
       createNewsItems(responseObject);
-
+    });
+  }else if(requestType === issueIdRequest){
+    xhr.open("GET", `https://cnbc.p.rapidapi.com/symbols/translate?symbol=${ticker}`);
+    xhr.addEventListener('load', function(){
+      console.log('status', xhr.status);
+      responseObject = JSON.parse(xhr.response);
+      responseObject = responseObject.issueId;
+      saveToWatchlist(ticker, xhr.response);
     });
   }
   xhr.setRequestHeader('x-rapidapi-key', 'afbc32455amsh2b70f92ea852178p1d2d81jsn1c3b08275a2e');
@@ -199,7 +215,7 @@ $stockPage.addEventListener('click', function () {
     switchPage(event.target);
   }else if(event.target.className === 'fas fa-plus'){
     switchPage(event.target);
-    saveToWatchlist(data.currentStock);
+    sendRequestCNBC(issueIdRequest, dataCurrentStock[0].Symbol, null);
   }
 });
 // window.addEventListener('load', getTrendingStories);

--- a/js/main.js
+++ b/js/main.js
@@ -40,7 +40,7 @@ function submitSearch(event) {
   clearRelatedNews();
   sendRequestAlphaVantage(overviewStatsRequest, $searchInput.value);
   sendRequestAlphaVantage(dailyStatsRequest, $searchInput.value);
-  // sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
+  sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
   $searchInput.value = '';
   removeSuggestionList();
   switchPage(event.target);

--- a/js/main.js
+++ b/js/main.js
@@ -182,7 +182,7 @@ function getPosOrNegClass(dataObject) {
   } else return 'loss-text';
 }
 
-function getWatchlistFromLocalStorage() {
+function getWatchlistFromDataModel() {
   for (var i = 0; i < data.watchlist.length; i++) {
     sendRequestAlphaVantage(dailyStatsRequest, data.watchlist[i], true);
   }
@@ -250,5 +250,5 @@ $stockPage.addEventListener('click', function () {
 });
 window.addEventListener('load', function () {
   getTrendingStories();
-  getWatchlistFromLocalStorage();
+  getWatchlistFromDataModel();
 });

--- a/js/main.js
+++ b/js/main.js
@@ -132,7 +132,7 @@ function switchPage(eventItem) {
   if (eventItem === $searchIcon) {
     $watchlistPage.classList.add('hidden');
     $stockPage.classList.remove('hidden');
-  } else if (eventItem.className === 'fas fa-times') {
+  } else if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
     $watchlistPage.classList.remove('hidden');
     $stockPage.classList.add('hidden');
   }
@@ -197,6 +197,9 @@ $searchIcon.addEventListener('click', submitSearch);
 $stockPage.addEventListener('click', function () {
   if (event.target.className === 'fas fa-times') {
     switchPage(event.target);
+  }else if(event.target.className === 'fas fa-plus'){
+    switchPage(event.target);
+    saveToWatchlist(data.currentStock);
   }
 });
-window.addEventListener('load', getTrendingStories);
+// window.addEventListener('load', getTrendingStories);

--- a/js/main.js
+++ b/js/main.js
@@ -146,8 +146,13 @@ function clearRelatedNews() {
   }
 }
 
+function saveStockToLocalStorage(){
+  var $ticker = document.querySelector('.stats-ticker');
+  data.wachlist.push($ticker.textContent);
+  generateWatchlistItem();
+}
 
-function createWatchlistItem(){
+function generateWatchlistItem(){
   // Get symbol and last close price from overview page and create
   var $listItem = document.createElement('li');
   var $ticker = document.createElement('p');
@@ -220,7 +225,7 @@ $stockPage.addEventListener('click', function () {
     switchPage(event.target);
   }else if(event.target.className === 'fas fa-plus'){
     switchPage(event.target);
-    createNewWatchlistItem();
+    saveStockToLocalStorage();
   }
 });
 // window.addEventListener('load', getTrendingStories);

--- a/js/main.js
+++ b/js/main.js
@@ -148,9 +148,9 @@ function clearRelatedNews() {
   }
 }
 
-function saveStockToLocalStorage(ticker){
+function saveStockToLocalStorage(){
   var $ticker = document.querySelector('.stats-ticker');
-  data.wachlist.push($ticker.textContent);
+  data.watchlist.push($ticker.textContent);
   sendRequestAlphaVantage(dailyStatsRequest, $ticker.textContent, forWatchlist);
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -42,7 +42,7 @@ function submitSearch(event) {
   clearRelatedNews();
   sendRequestAlphaVantage(overviewStatsRequest, $searchInput.value, false);
   sendRequestAlphaVantage(dailyStatsRequest, $searchInput.value, false);
-  sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
+  // sendRequestCNBC(companyNewsRequest, $searchInput.value, null);
   $searchInput.value = '';
   removeSuggestionList();
   switchPage(event.target);
@@ -148,29 +148,40 @@ function clearRelatedNews() {
   }
 }
 
-function saveStockToLocalStorage(){
+function saveStockToLocalStorage(ticker){
   var $ticker = document.querySelector('.stats-ticker');
   data.wachlist.push($ticker.textContent);
   sendRequestAlphaVantage(dailyStatsRequest, $ticker.textContent, forWatchlist);
 }
 
 function generateWatchlistItem(dataObject){
-  var lastTradingDate = dataObject['Meta Data']['3. Last Refreshed'];
+  var lastTradingDate = dataObject['Meta Data']['3. Last Refreshed'].slice(0, 10);
   var listItem = document.createElement('li');
   var ticker = document.createElement('p');
   var column = document.createElement('div');
   var price = document.createElement('p');
-  listItem.classList = 'watchlist-item-head row column-full';
-  ticker.classList = 'ticker';
-  column.classList = 'price-column';
-  column.classList = 'price';
+  listItem.className = 'watchlist-item-head row column-full';
+  ticker.className = 'ticker';
+  column.className = 'price-column';
+  price.className = 'price';
+  price.classList.add(getPosOrNegClass(dataObject));
   ticker.textContent = dataObject['Meta Data']['2. Symbol'];
-  price.textContent = cutPrice(dataObject['Time Series (Daily)'][lastTradingDate]['4. close']);
+  price.textContent = '$' + cutPrice(dataObject['Time Series (Daily)'][lastTradingDate]['4. close']);
   column.appendChild(price);
   listItem.appendChild(ticker);
   listItem.appendChild(column);
   $watchlistList.appendChild(listItem);
+}
 
+function getPosOrNegClass(dataObject){
+  var date = dataObject['Meta Data']['3. Last Refreshed'].slice(0,10);
+  var open = cutPrice(dataObject['Time Series (Daily)'][date]['1. open']);
+  var close = cutPrice(dataObject['Time Series (Daily)'][date]['4. close']);
+  open = parseInt(open);
+  close = parseInt(close);
+  if(close >= open){
+    return 'profit-text';
+  }else return 'loss-text'
 }
 
 // Request Functions

--- a/js/main.js
+++ b/js/main.js
@@ -146,12 +146,17 @@ function clearRelatedNews() {
   }
 }
 
-function saveToWatchlist(symbol, id){
-  var watchlistObject = {}
-  watchlistObject.ticker = symbol;
-  watchlistObject.issueId = id;
-  data.wachlist.push(watchlistObject);
-  //create list item with current data, future log-on will create items from local storage
+
+function createWatchlistItem(){
+  // Get symbol and last close price from overview page and create
+  var $listItem = document.createElement('li');
+  var $ticker = document.createElement('p');
+  var $column = document.createElement('div');
+  var $price = document.createElement('p');
+  $listItem.classList = 'watchlist-item-head row column-full';
+  $ticker.classList = 'ticker';
+  $column.classList = 'price-column';
+  $column.classList = 'price';
 }
 
 // Request Functions
@@ -215,7 +220,7 @@ $stockPage.addEventListener('click', function () {
     switchPage(event.target);
   }else if(event.target.className === 'fas fa-plus'){
     switchPage(event.target);
-    sendRequestCNBC(issueIdRequest, dataCurrentStock[0].Symbol, null);
+    createNewWatchlistItem();
   }
 });
 // window.addEventListener('load', getTrendingStories);


### PR DESCRIPTION
Home page with a list of already saved stocks (pulled from local storage) and the latest trending market news from CNBC:

![Screen Shot 2021-02-26 at 4 48 32 PM](https://user-images.githubusercontent.com/75342275/109370655-10d75480-7856-11eb-905f-d2c29f5b2861.png)

Search for Stocks with autocomplete: 

![Screen Shot 2021-02-26 at 4 48 47 PM](https://user-images.githubusercontent.com/75342275/109370678-36645e00-7856-11eb-8997-036e78457262.png)

Pull up stats for last completed trading day and news related to that company:

![Screen Shot 2021-02-26 at 5 04 53 PM](https://user-images.githubusercontent.com/75342275/109370721-67dd2980-7856-11eb-87ca-ba03d0e67b9a.png)

On save, item gets added to watchlist and saved in the data model:

![Screen Shot 2021-02-26 at 4 53 17 PM](https://user-images.githubusercontent.com/75342275/109370785-aa066b00-7856-11eb-93dd-130ecbf56194.png)

Some pics of desktop/tablet view:
![Screen Shot 2021-02-26 at 5 01 31 PM](https://user-images.githubusercontent.com/75342275/109370796-b4286980-7856-11eb-92a6-1c30bda8ea66.png)
![Screen Shot 2021-02-26 at 5 01 49 PM](https://user-images.githubusercontent.com/75342275/109370797-b5599680-7856-11eb-8be6-18dba5501121.png)
![Screen Shot 2021-02-26 at 5 02 52 PM](https://user-images.githubusercontent.com/75342275/109370798-b5f22d00-7856-11eb-870e-7057004a80bd.png)

