### PR TITLE
Issue 4 user can click on watchlist item and quick open its stat page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -96,12 +96,18 @@ i.fa-pen {
   font-weight: 300;
 }
 
-.watchlist-item-head,
+.watchlist-item,
 .lists-sections,
 .stats-header,
 .table-header,
 .stock-page {
   justify-content: space-between;
+}
+
+.watchlist-item {
+  border-bottom: 1px solid #393e42;
+  margin: 0.2rem 0;
+  padding-left: 10px;
 }
 
 .price-column {
@@ -201,11 +207,11 @@ i.fa-pen {
   background-color: #b6ecb4;
 }
 
-.profit-text{
+.profit-text {
   color: green;
 }
 
-.loss-text{
+.loss-text {
   color: red;
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -96,6 +96,7 @@ i.fa-pen {
   font-weight: 300;
 }
 
+.watchlist-item-head,
 .watchlist-item,
 .lists-sections,
 .stats-header,

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <span class="full-bar column-full"></span>
           </header>
           <ul class="watchlist column-full">
-            <li class="watchlist-item row column-full">
+            <li class="watchlist-item-head row column-full">
               <p class="ticker">SYMBOL</p>
               <div class="price-column">
                 <p class="price">&dollar;&dollar;&dollar;</p>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <span class="full-bar column-full"></span>
           </header>
           <ul class="watchlist column-full">
-            <li class="watchlist-item-head row column-full">
+            <li class="watchlist-item row column-full">
               <p class="ticker">SYMBOL</p>
               <div class="price-column">
                 <p class="price">&dollar;&dollar;&dollar;</p>

--- a/js/data.js
+++ b/js/data.js
@@ -1,9 +1,9 @@
 /* exported data */
 var data = {
-  view: null,
   suggestionData: null,
   currentStock: [],
-  watchlist: []
+  watchlist: [],
+  plusIcon: 'show'
 }
 var previousDataJSON = localStorage.getItem('watchlistData');
 

--- a/js/main.js
+++ b/js/main.js
@@ -7,6 +7,7 @@ var $stockNewsList = document.querySelector('.stock-news-list');
 var $watchlistList = document.querySelector('.watchlist');
 var $watchlistPage = document.querySelector('.watchlist-page');
 var $stockPage = document.querySelector('.stock-page');
+var $plusIcon = document.querySelector('.fa-plus');
 var dailyStatsRequest = 'TIME_SERIES_DAILY';
 var overviewStatsRequest = 'OVERVIEW';
 var trendingStoriesRequest = 'TRENDING';
@@ -130,13 +131,16 @@ function cutPrice(string) {
 }
 
 function switchPage(eventItem) {
- if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
+  if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
     $watchlistPage.classList.remove('hidden');
     $stockPage.classList.add('hidden');
   }else{
     $watchlistPage.classList.add('hidden');
     $stockPage.classList.remove('hidden');
   }
+  if(data.plusIcon === 'hide'){
+    $plusIcon.classList.add('hidden');
+  }else $plusIcon.className = 'fas fa-plus';
 }
 
 function clearRelatedNews() {
@@ -244,7 +248,9 @@ $suggestionBox.addEventListener('click', loadSuggestion);
 $searchIcon.addEventListener('click', submitSearch);
 $stockPage.addEventListener('click', function () {
   if (event.target.className === 'fas fa-times') {
+    data.plusIcon = 'show';
     switchPage(event.target);
+
   } else if (event.target.className === 'fas fa-plus') {
     switchPage(event.target);
     saveStockToLocalStorage();
@@ -257,10 +263,11 @@ $watchlistList.addEventListener('click', function () {
     var ticker = tickerElement.textContent;
     sendRequestAlphaVantage(overviewStatsRequest, ticker, false);
     sendRequestAlphaVantage(dailyStatsRequest, ticker, false);
+    data.plusIcon = 'hide';
     switchPage(event.target);
   }
 });
 window.addEventListener('load', function () {
-  // getTrendingStories();
+  getTrendingStories();
   getWatchlistFromDataModel();
 });

--- a/js/main.js
+++ b/js/main.js
@@ -134,13 +134,13 @@ function switchPage(eventItem) {
   if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
     $watchlistPage.classList.remove('hidden');
     $stockPage.classList.add('hidden');
-  }else{
+  } else {
     $watchlistPage.classList.add('hidden');
     $stockPage.classList.remove('hidden');
   }
-  if(data.plusIcon === 'hide'){
+  if (data.plusIcon === 'hide') {
     $plusIcon.classList.add('hidden');
-  }else $plusIcon.className = 'fas fa-plus';
+  } else $plusIcon.className = 'fas fa-plus';
 }
 
 function clearRelatedNews() {
@@ -201,8 +201,6 @@ function sendRequestAlphaVantage(functionType, ticker, isWatchlist) {
     if (isWatchlist === true) {
       generateWatchlistItem(xhr.response);
     } else {
-      console.log(xhr.status);
-      console.log(xhr.response);
       data.currentStock.push(xhr.response);
       loadStats(data.currentStock);
     }
@@ -257,12 +255,13 @@ $stockPage.addEventListener('click', function () {
   }
 });
 $watchlistList.addEventListener('click', function () {
-  if(event.target.closest('.watchlist-item')){
+  if (event.target.closest('.watchlist-item')) {
     var item = event.target.closest('.watchlist-item');
     var tickerElement = item.querySelector('.ticker');
     var ticker = tickerElement.textContent;
     sendRequestAlphaVantage(overviewStatsRequest, ticker, false);
     sendRequestAlphaVantage(dailyStatsRequest, ticker, false);
+    sendRequestCNBC(companyNewsRequest, ticker, null);
     data.plusIcon = 'hide';
     switchPage(event.target);
   }

--- a/js/main.js
+++ b/js/main.js
@@ -248,6 +248,9 @@ $stockPage.addEventListener('click', function () {
     saveStockToLocalStorage();
   }
 });
+$watchlistList.addEventListener('click', function () {
+
+});
 window.addEventListener('load', function () {
   getTrendingStories();
   getWatchlistFromDataModel();

--- a/js/main.js
+++ b/js/main.js
@@ -130,12 +130,12 @@ function cutPrice(string) {
 }
 
 function switchPage(eventItem) {
-  if (eventItem === $searchIcon) {
-    $watchlistPage.classList.add('hidden');
-    $stockPage.classList.remove('hidden');
-  } else if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
+ if (eventItem.className === 'fas fa-times' || eventItem.className === 'fas fa-plus') {
     $watchlistPage.classList.remove('hidden');
     $stockPage.classList.add('hidden');
+  }else{
+    $watchlistPage.classList.add('hidden');
+    $stockPage.classList.remove('hidden');
   }
 }
 
@@ -197,6 +197,8 @@ function sendRequestAlphaVantage(functionType, ticker, isWatchlist) {
     if (isWatchlist === true) {
       generateWatchlistItem(xhr.response);
     } else {
+      console.log(xhr.status);
+      console.log(xhr.response);
       data.currentStock.push(xhr.response);
       loadStats(data.currentStock);
     }
@@ -249,9 +251,16 @@ $stockPage.addEventListener('click', function () {
   }
 });
 $watchlistList.addEventListener('click', function () {
-
+  if(event.target.closest('.watchlist-item')){
+    var item = event.target.closest('.watchlist-item');
+    var tickerElement = item.querySelector('.ticker');
+    var ticker = tickerElement.textContent;
+    sendRequestAlphaVantage(overviewStatsRequest, ticker, false);
+    sendRequestAlphaVantage(dailyStatsRequest, ticker, false);
+    switchPage(event.target);
+  }
 });
 window.addEventListener('load', function () {
-  getTrendingStories();
+  // getTrendingStories();
   getWatchlistFromDataModel();
 });

--- a/js/main.js
+++ b/js/main.js
@@ -158,7 +158,7 @@ function generateWatchlistItem(dataObject) {
   var ticker = document.createElement('p');
   var column = document.createElement('div');
   var price = document.createElement('p');
-  listItem.className = 'watchlist-item-head row column-full';
+  listItem.className = 'watchlist-item row column-full';
   ticker.className = 'ticker';
   column.className = 'price-column';
   price.className = 'price';


### PR DESCRIPTION
Home page with data loaded from local storage and trending news courtesy of cnbc api:
![Screen Shot 2021-03-01 at 6 06 14 PM](https://user-images.githubusercontent.com/75342275/109586267-c0603100-7ab9-11eb-8cb9-0e399af97641.png)

When watchlist item is clicked on, stats page opens and 'add' icon is hidden from this view.

![Screen Shot 2021-03-01 at 6 08 40 PM](https://user-images.githubusercontent.com/75342275/109586325-de2d9600-7ab9-11eb-80a2-5e3a39340554.png)
